### PR TITLE
Improve change null check

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,13 +5,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -19,11 +18,11 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/main.js
+++ b/main.js
@@ -81,6 +81,12 @@ function getUpcomingTrainingWeekDayDate(trainingDay) {
   return getTrainingDateAsGermanDateFormat(trainingDate);
 }
 
+function newSheet(spreadsheetApp, sheetName) {
+  const sheet = spreadsheetApp.insertSheet(sheetName);
+
+  return sheet.appendRow(["Name", "Eingetragen um"]);
+}
+
 function saveNewTrainingAttendeeToSpreadSheet(
   fullTrainingWeekDayName,
   upcomingTrainingWeekDayDate,
@@ -89,13 +95,13 @@ function saveNewTrainingAttendeeToSpreadSheet(
 ) {
   const spreadsheetName =
     fullTrainingWeekDayName + " " + upcomingTrainingWeekDayDate;
-  let spreadsheet = spreadsheetApp.getSheetByName(fullTrainingWeekDayName);
+  let spreadsheet = spreadsheetApp.getSheetByName(spreadsheetName);
 
-  if (typeof spreadsheet === "undefined" && (typeof spreadsheet !== "object" || !spreadsheet)) {
-    spreadsheet = spreadsheetApp.insertSheet(spreadsheetName);
+  if (spreadsheet == null) {
+    spreadsheet = newSheet(spreadsheetApp, spreadsheetName);
   }
 
-  spreadsheet.appendRow([userName, Date.now()]);
+  spreadsheet.appendRow([userName, new Date().toISOString()]);
 
   return spreadsheetName;
 }


### PR DESCRIPTION
Currently I'm getting the following error while trying to add myself to the `Samstag` spreadsheet.

```
<!DOCTYPE html><html><head><link rel="shortcut icon" href="//ssl.gstatic.com/docs/script/images/favicon.ico"><title>Error</title><style type="text/css">body {background-color: #fff; margin: 0; padding: 0;}.errorMessage {font-family: Arial,sans-serif; font-size: 12pt; font-weight: bold; line-height: 150%; padding-top: 25px;}</style></head><body style="margin:20px"><div><img alt="Google Apps Script" src="//ssl.gstatic.com/docs/script/images/logo.png"></div><div style="text-align:center;font-family:monospace;margin:50px auto 0;max-width:600px">Exception: Es ist bereits ein Tabellenblatt mit dem Namen &quot;Samstag 19.9.2020&quot; vorhanden. Geben Sie einen anderen Namen ein. (line 96, file &quot;Code&quot;)</div></body></html>
```

![Screenshot 2020-09-19 at 00 21 03](https://user-images.githubusercontent.com/4670057/93650146-0181ee80-fa0e-11ea-89fe-f2860feccf16.jpg)

**This change tries to mitigate the issue with**
• Changing null check to `typeof spreadsheet === "undefined"` [1]

**Some minor improvements**
• Remove redundant channel name paramter
• Change string equal check from `==` to `===`

**FYI:**
I tried to verify the fix with deploying version 10 on the Google Apps Script but got an permission error I wasn't privileged to deploy the new version as an contributor.
![Screenshot 2020-09-19 at 00 26 01](https://user-images.githubusercontent.com/4670057/93650416-ba482d80-fa0e-11ea-9964-b6aeebde6b0d.jpg)


[1] https://medium.com/javascript-in-plain-english/how-to-check-for-null-in-javascript-dffab64d8ed5